### PR TITLE
Add request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Connection errors (for example, due to a network connectivity problem), 409 Conf
 and >=500 Internal errors will all be retried by default.
 
 You can disable or configure this behavior by passing `maxRetries: 0` to the client instantiation
-or in a request's options, e.g.;
+or in a request's options, e.g.:
 
 ```js
 // Configure the default across the library:
@@ -116,6 +116,23 @@ const lithic = new Lithic(process.env.LITHIC_API_KEY, {
 // Or, configure this per-request:
 lithic.cards.list({page_size: 5}, {maxRetries: 5});
 ```
+
+### Timeouts
+
+By default requests timeout after 80 seconds. A different timeout value can set by using the client option `timeout`
+when instantiating the client, or in a request's options. The provided value is in millisecond, `timeout: 1000` will
+make request timeout after 1 second. E.g.:
+
+```
+const lithic = new Lithic(process.env.LITHIC_API_KEY, {
+  timeout: 20 * 1000, // 20 seconds
+});
+
+// Or, configure per-request:
+lithic.cards.list({page_size: 5}, {timeout: 5 * 1000});
+```
+
+On timeout an error `APIConnectionTimeoutError` is thrown.
 
 ## Auto-pagination
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Connection errors (for example, due to a network connectivity problem), 409 Conf
 and >=500 Internal errors will all be retried by default.
 
 You can disable or configure this behavior by passing `maxRetries: 0` to the client instantiation
-or in a request's options, e.g.:
+or in a request's options, e.g.,
 
 ```js
 // Configure the default across the library:
@@ -119,9 +119,8 @@ lithic.cards.list({page_size: 5}, {maxRetries: 5});
 
 ### Timeouts
 
-By default requests timeout after 80 seconds. A different timeout value can set by using the client option `timeout`
-when instantiating the client, or in a request's options. The provided value is in millisecond, `timeout: 1000` will
-make request timeout after 1 second. E.g.:
+Requests time out after 80 seconds by default. You may pass a timeout option when instantiating the client or sending a
+request to override this, e.g.,
 
 ```
 const lithic = new Lithic(process.env.LITHIC_API_KEY, {
@@ -129,10 +128,12 @@ const lithic = new Lithic(process.env.LITHIC_API_KEY, {
 });
 
 // Or, configure per-request:
-lithic.cards.list({page_size: 5}, {timeout: 5 * 1000});
+lithic.cards.list({page_size: 5}, {timeout: 5 * 1000}); // 5 seconds
 ```
 
-On timeout an error `APIConnectionTimeoutError` is thrown.
+On timeout an `APIConnectionTimeoutError` is thrown.
+
+> Note that request which time out will be [retried twice by default](#retries).
 
 ## Auto-pagination
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ lithic.cards.list({page_size: 5}, {maxRetries: 5});
 
 ### Timeouts
 
-Requests time out after 80 seconds by default. You may pass a timeout option when instantiating the client or sending a
+Requests time out after 60 seconds by default. You may pass a `timeout` option when instantiating the client or sending a
 request to override this, e.g.,
 
 ```
@@ -128,12 +128,14 @@ const lithic = new Lithic(process.env.LITHIC_API_KEY, {
 });
 
 // Or, configure per-request:
-lithic.cards.list({page_size: 5}, {timeout: 5 * 1000}); // 5 seconds
+lithic.cards.list({page_size: 5}, {
+  timeout: 5 * 1000 // 5 seconds
+});
 ```
 
-On timeout an `APIConnectionTimeoutError` is thrown.
+On timeout, an `APIConnectionTimeoutError` is thrown.
 
-> Note that request which time out will be [retried twice by default](#retries).
+Note that request which time out will be [retried twice by default](#retries).
 
 ## Auto-pagination
 

--- a/core.ts
+++ b/core.ts
@@ -71,7 +71,7 @@ export abstract class APIClient {
     this.debug('request', url, options, req.headers);
 
     const fetchPromise = fetch(url, req).catch(() => null);
-    let timeoutId: NodeJS.Timeout | null;
+    let timeoutId: ReturnType<typeof setTimeout> | null;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         timeoutId = null;

--- a/core.ts
+++ b/core.ts
@@ -3,22 +3,29 @@ import qs from 'qs';
 import {makeAutoPaginationMethods, AutoPaginationMethods} from './pagination';
 import pkgUp from 'pkg-up';
 
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_TIMEOUT = 80 * 1000; // 80s
+
 export abstract class APIClient {
   apiKey: string;
   baseURL: string;
   maxRetries: number;
+  timeout: number;
   constructor({
     apiKey,
     baseURL,
-    maxRetries = 2,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    timeout = DEFAULT_TIMEOUT,
   }: {
     apiKey: string;
     baseURL: string;
     maxRetries?: number;
+    timeout: number | undefined;
   }) {
     this.apiKey = apiKey;
     this.baseURL = baseURL;
-    this.maxRetries = maxRetries;
+    this.maxRetries = validatePositiveInteger('maxRetries', maxRetries);
+    this.timeout = validatePositiveInteger('timeout', timeout);
   }
 
   /**
@@ -44,6 +51,9 @@ export abstract class APIClient {
   ): Promise<APIResponse<Rsp>> {
     const {method, path, query, body, headers} = options;
 
+    const timeout = options.timeout || this.timeout;
+    validatePositiveInteger('timeout', timeout);
+
     const url = this.buildURL(path!, query);
     const jsonBody = body && JSON.stringify(body, null, 2);
     const contentLength = jsonBody?.length.toString();
@@ -60,8 +70,20 @@ export abstract class APIClient {
 
     this.debug('request', url, options, req.headers);
 
-    const response = await fetch(url, req).catch(() => null);
+    const fetchPromise = fetch(url, req).catch(() => null);
+    let timeoutId: NodeJS.Timeout | null;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+        reject(new APIConnectionTimeoutError());
+      }, timeout);
+    });
 
+    const response = await Promise.race([fetchPromise, timeoutPromise]).finally(
+      () => {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+    );
     if (!response) {
       if (retriesRemaining) return this.retryRequest(options, retriesRemaining);
 
@@ -259,6 +281,7 @@ export type RequestOptions<Req extends {} = Record<string, unknown>> = {
   headers?: Headers | undefined;
 
   maxRetries?: number;
+  timeout?: number;
 };
 
 export type FinalRequestOptions<Req extends {} = Record<string, unknown>> =
@@ -354,8 +377,14 @@ export class InternalServerError extends APIError {}
 export class APIConnectionError extends APIError {
   override readonly status: undefined;
 
+  constructor(message: string = 'Connection error.') {
+    super(undefined, undefined, message, undefined);
+  }
+}
+
+export class APIConnectionTimeoutError extends APIConnectionError {
   constructor() {
-    super(undefined, undefined, 'Connection error.', undefined);
+    super('Request timed out.');
   }
 }
 
@@ -414,3 +443,13 @@ const safeJSON = (text: string) => {
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const validatePositiveInteger = (name: string, n: number) => {
+  if (!Number.isInteger(n)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  if (n < 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return n;
+};

--- a/core.ts
+++ b/core.ts
@@ -4,7 +4,7 @@ import {makeAutoPaginationMethods, AutoPaginationMethods} from './pagination';
 import pkgUp from 'pkg-up';
 
 const DEFAULT_MAX_RETRIES = 2;
-const DEFAULT_TIMEOUT = 80 * 1000; // 80s
+const DEFAULT_TIMEOUT = 60 * 1000; // 60s
 
 export abstract class APIClient {
   apiKey: string;

--- a/example.ts
+++ b/example.ts
@@ -95,11 +95,17 @@ async function main() {
     }
   });
 
-  // timeout error
+  // per-request timeout error
   await lithic.cards
-    .create({type: 'SINGLE_USE'}, {timeout: 100 /* 100ms should be too short*/})
+    .create(
+      {type: 'SINGLE_USE'},
+      {timeout: 100 /* 100ms should be too short and fail with a timeout */}
+    )
     .catch((e: unknown) => {
-      if (e instanceof Lithic.APIConnectionTimeoutError) {
+      if (
+        e instanceof Lithic.APIConnectionTimeoutError &&
+        e instanceof Lithic.APIConnectionError // should subclass APIConnectionError
+      ) {
         console.log('Request timed out!', e);
       } else {
         throw e;

--- a/example.ts
+++ b/example.ts
@@ -3,6 +3,7 @@ import Lithic from './index';
 
 const lithic = new Lithic('5344d81a-da4a-4843-bce5-5495e79096b3', {
   environment: 'sandbox',
+  timeout: 10 * 1000,
 });
 
 const hmacSignature = (key: string, msg: string): string => {
@@ -93,6 +94,17 @@ async function main() {
       throw e;
     }
   });
+
+  // timeout error
+  await lithic.cards
+    .create({type: 'SINGLE_USE'}, {timeout: 100 /* 100ms should be too short*/})
+    .catch((e: unknown) => {
+      if (e instanceof Lithic.APIConnectionTimeoutError) {
+        console.log('Request timed out!', e);
+      } else {
+        throw e;
+      }
+    });
 }
 
 main().catch(console.error);

--- a/index.ts
+++ b/index.ts
@@ -12,14 +12,17 @@ export class Lithic extends Core.APIClient {
     {
       environment = 'production',
       baseURL,
+      timeout,
     }: {
       environment?: keyof typeof environments;
       baseURL?: string;
+      timeout?: number;
     } = {}
   ) {
     super({
       apiKey,
       baseURL: baseURL || environments[environment],
+      timeout,
     });
   }
 
@@ -64,6 +67,7 @@ export class Lithic extends Core.APIClient {
   static PermissionDeniedError = Core.PermissionDeniedError;
   static RateLimitError = Core.RateLimitError;
   static UnprocessableEntityError = Core.UnprocessableEntityError;
+  static APIConnectionTimeoutError = Core.APIConnectionTimeoutError;
 }
 
 export namespace Lithic {


### PR DESCRIPTION
This adds a configurable request timeout, with a default of 60 seconds.