### PR TITLE
Change email or fix permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package is in beta. Its internals and interfaces are not stable
 and subject to change without a major semver bump;
 please reach out if you rely on any undocumented behavior.
 
-We are keen for your feedback; please email us at [lithic-sdk-feedback@lithic.com](mailto:lithic-sdk-feedback@lithic.com)
+We are keen for your feedback; please email us at [support@lithic.com](mailto:support@lithic.com)
 with questions, bugs, or suggestions.
 
 ## Installation


### PR DESCRIPTION
That email does not allow external folks to email it. We should fix the permissions or you can send them to support.